### PR TITLE
Add usesRAM tag to HTML template

### DIFF
--- a/templates/tag_summary_template.html
+++ b/templates/tag_summary_template.html
@@ -77,6 +77,9 @@
                         {% if subtag.unresolved.isBuffer %}
                             <li>This register is a <a href="https://labjack.com/support/datasheets/t7/communication/modbus-map/buffer-registers">Buffer Register</a></li>
                         {% endif %}
+                        {% if subtag.unresolved.usesRAM %}
+                            <li>This register uses system RAM. The maximum ram is 64KB. For more information, see <a href="/support/datasheets/t-series/hardware-overview/ram">4.4 RAM</a></li>
+                        {% endif %}
                         {% for unres_device in subtag.unresolved.devices %}
                             {% if unres_device.description or unres_device.default or unres_device.fwmin %}
                                 <li>{{ unres_device.device }}:<ul>


### PR DESCRIPTION
Works with tags:
STREAM_ENABLE
STREAM_OUT#(0:3)_ENABLE
LUA_RUN
LUA_SOURCE_SIZE
LUA_DEBUG_ENABLE
USER_RAM_FIFO#(0:3)_ALLOCATE_NUM_BYTES
AIN#(0:149)_EF_INDEX
AIN#(0:149)_EF_READ_A
FILE_IO_PATH_WRITE_LEN_BYTES
SPI_GO
ASYNCH_NUM_BYTES_TX
ASYNCH_ENABLE

And not with any others 